### PR TITLE
Added a playInVR method to launch WDGFWorld objects in VR headsets.

### DIFF
--- a/tonel/WodenGameFramework-OSWindow/WDGFWorld.extension.st
+++ b/tonel/WodenGameFramework-OSWindow/WDGFWorld.extension.st
@@ -14,3 +14,12 @@ WDGFWorld >> playInOSWindow [
 		wodenWorld: self;
 		open
 ]
+
+{ #category : #'*WodenGameFramework-OSWindow' }
+WDGFWorld >> playInVR [
+	self beginPlay.
+	^ WDGFWorldOSWindow new
+		vrEnabled: true;
+		wodenWorld: self;
+		open
+]


### PR DESCRIPTION
I added a method named "playInVR" to open a WDGFWorld in VR environment.
It's basically a copy of the "openInVR" method which opens a WDScene in VR environment.